### PR TITLE
Add additional "!mp settings" parsing 

### DIFF
--- a/BanchoSharp/Interfaces/IMultiplayerLobby.cs
+++ b/BanchoSharp/Interfaces/IMultiplayerLobby.cs
@@ -89,11 +89,4 @@ public interface IMultiplayerLobby : IChatChannel
 	public Task RemoveRefereesAsync(params string[] usernames);
 	public Task SetMapAsync(BeatmapShell beatmap);
 	public Task SendHelpMessageAsync();
-
-	/// <summary>
-	///  Updates this object's properties based on what is currently
-	///  set in the multplayer lobby
-	/// </summary>
-	/// <returns></returns>
-	public Task UpdateAsync();
 }

--- a/BanchoSharp/Multiplayer/MultiplayerLobby.cs
+++ b/BanchoSharp/Multiplayer/MultiplayerLobby.cs
@@ -257,43 +257,6 @@ public class MultiplayerLobby : Channel, IMultiplayerLobby
 
 	public async Task SendHelpMessageAsync() => await SendAsync("!mp help");
 
-	// Untested
-	public async Task UpdateAsync()
-	{
-		int count = 0;
-		var sw = new Stopwatch();
-		sw.Start();
-
-		var trackSettingsMessages = delegate(IPrivateIrcMessage message)
-		{
-			if (message.Sender == "BanchoBot" && message.Recipient == Name)
-			{
-				UpdateLobbyFromBanchoBotSettingsResponse(message.Content);
-				count++;
-			}
-		};
-
-		_client.OnMessageReceived += m =>
-		{
-			if (m is IPrivateIrcMessage dm)
-			{
-				trackSettingsMessages(dm);
-			}
-		};
-
-		while (count < 3 && sw.ElapsedMilliseconds < 10000)
-		{
-			await Task.Delay(25);
-		}
-
-		if (sw.ElapsedMilliseconds >= 10000)
-		{
-			Logger.Warn("Multiplayer settings update watcher timed out");
-		}
-
-		OnSettingsUpdated?.Invoke();
-	}
-
 	// private Task TimerWatcher()
 	// {
 	// 	while (true)


### PR DESCRIPTION
This PR removes the old updating system. Instead it automatically notifies the user when a `!mp settings`  event has been parsed, and can now load existing players and/or host changes.