### PR TITLE
Fix UpdatePlayerSlotMove crash

### DIFF
--- a/BanchoSharp/Multiplayer/MultiplayerLobby.cs
+++ b/BanchoSharp/Multiplayer/MultiplayerLobby.cs
@@ -552,9 +552,8 @@ public class MultiplayerLobby : Channel, IMultiplayerLobby
 
 		if (player is null)
 		{
-			// This may happen if couldn't track the user joining in the first place,
-			// which shouldn't be very often.
-			return;
+			player = new MultiplayerPlayer(name, slotNum);
+			Players.Add(player);
 		}
 		
 		int previousSlot = player!.Slot;

--- a/BanchoSharp/Multiplayer/MultiplayerLobby.cs
+++ b/BanchoSharp/Multiplayer/MultiplayerLobby.cs
@@ -549,6 +549,14 @@ public class MultiplayerLobby : Channel, IMultiplayerLobby
 		int slotNum = int.Parse(slot);
 
 		var player = FindPlayer(name);
+
+		if (player is null)
+		{
+			// This may happen if couldn't track the user joining in the first place,
+			// which shouldn't be very often.
+			return;
+		}
+		
 		int previousSlot = player!.Slot;
 		player.Slot = slotNum;
 


### PR DESCRIPTION
If a player changes slot and is not present in the `Players` list, the application would crash due to a `System.NullReferenceException`. 