### PR TITLE
Fix `TargetableName` with names that includes a space

### DIFF
--- a/BanchoSharp/Multiplayer/MultiplayerPlayer.cs
+++ b/BanchoSharp/Multiplayer/MultiplayerPlayer.cs
@@ -32,7 +32,7 @@ public class MultiplayerPlayer : IMultiplayerPlayer
 	public bool? Passed { get; set; }
 	public bool IsReady { get; set; }
 	public IMultiplayerLobby? Lobby { get; set; }
-	public string TargetableName() => Id.HasValue ? $"#{Id}" : Name;
+	public string TargetableName() => Id.HasValue ? $"#{Id}" : Name.Replace(' ', '_');
 
 	public override bool Equals(object? other) => other?.GetType() == typeof(MultiplayerPlayer) &&
 	                                              Name.Equals((other as MultiplayerPlayer)!.Name);

--- a/BanchoSharpTests/MultiplayerTests.cs
+++ b/BanchoSharpTests/MultiplayerTests.cs
@@ -249,9 +249,9 @@ public class MultiplayerTests
 	[Test]
 	public void TestTargetableName()
 	{
-		_lobby.Players.Add(new MultiplayerPlayer(_lobby, "Foo", 1, TeamColor.Red));
+		_lobby.Players.Add(new MultiplayerPlayer(_lobby, "Foo bar", 1, TeamColor.Red));
 
-		Assert.That(_lobby.Players.First().TargetableName().Equals("Foo"));
+		Assert.That(_lobby.Players.First().TargetableName().Equals("Foo_bar"));
 
 		_lobby.Players.First().Id = 123;
 		Assert.That(_lobby.Players.First().TargetableName().Equals("#123"));


### PR DESCRIPTION
As noted in the [Tournament management commands wiki page](https://osu.ppy.sh/wiki/en/osu%21_tournament_client/osu%21tourney/Tournament_management_commands), names with spaces needs to be replaced with underscores in order for Bancho to target them properly.