### PR TITLE
Fix ordering of WinCondition enum to match Bancho

### DIFF
--- a/BanchoSharp/Multiplayer/MultiplayerLobby.cs
+++ b/BanchoSharp/Multiplayer/MultiplayerLobby.cs
@@ -17,9 +17,9 @@ public enum LobbyFormat
 public enum WinCondition
 {
 	Score,
-	ScoreV2,
 	Accuracy,
-	Combo
+	Combo,
+	ScoreV2
 }
 
 public enum GameMode


### PR DESCRIPTION
Minor change, but the current order of WinCondition (score mode) doesn't match Bancho, as seen [here](https://osu.ppy.sh/wiki/en/osu%21_tournament_client/osu%21tourney/Tournament_management_commands#:~:text=scoremode%20%2D%200%3A%20Score%2C%201%3A%20Accuracy%2C%202%3A%20Combo%2C%203%3A%20Score%20V2), which means directly casting this to an integer to be used within for example `!mp set` wouldn't work.