### PR TITLE
Fix both doubletime and nightcore being enabled at the same time

### DIFF
--- a/BanchoSharp/Multiplayer/MultiplayerLobby.cs
+++ b/BanchoSharp/Multiplayer/MultiplayerLobby.cs
@@ -1139,6 +1139,11 @@ public sealed class MultiplayerLobby : Channel, IMultiplayerLobby
 			}
 		}
 
+		// Bancho will report that both Doubletime and Nightcore is enabled whenever Nightcore is picked, causing
+		// the parsing above to mark both mods as enabled. So if nightcore is set, disable doubletime.
+		if ((Mods & Mods.Nightcore) != 0)
+			Mods &= ~Mods.DoubleTime;
+
 		// Update mods for all players in the lobby
 		foreach (var player in Players)
 		{


### PR DESCRIPTION
Closes #35. If Nightcore is picked, Bancho will report both DoubleTime and Nightcore being enabled, which will cause the parsing code to mark both as enabled at the same time. I don't personally feel the reason to overcomplicate this, so this PR will just remove DT if NC is enabled.